### PR TITLE
Add public feed page to chat app

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
@@ -1,11 +1,16 @@
 package com.google.codeu.servlets;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.codeu.data.Datastore;
+import com.google.codeu.data.Message;
+import com.google.gson.Gson;
 
 /**
  * Handles fetching all messages for the public feed.
@@ -13,10 +18,26 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/feed")
 public class MessageFeedServlet extends HttpServlet{
 
+ private Datastore datastore;
+
+ @Override
+ public void init() {
+  datastore = new Datastore();
+ }
+
+ /**
+  * Responds with a JSON representation of Message data for all users.
+  */
  @Override
  public void doGet(HttpServletRequest request, HttpServletResponse response)
    throws IOException {
 
-  response.getOutputStream().println("this will be my message feed");
+  response.setContentType("application/json");
+
+  List<Message> messages = datastore.getAllMessages();
+  Gson gson = new Gson();
+  String json = gson.toJson(messages);
+
+  response.getOutputStream().println(json);
  }
 }

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Message Feed</title>
+<link rel="stylesheet" href="/css/main.css">
+<link rel="stylesheet" href="/css/user-page.css">
+
+<script src="/js/feed-loader.js"></script>
+</head>
+<body onload="buildUI()">
+ <div id="content">
+  <h1>Message Feed</h1>
+  <hr/>
+  <div id="message-container">Loading...</div>
+ </div>
+</body>
+</html>

--- a/src/main/webapp/js/feed-loader.js
+++ b/src/main/webapp/js/feed-loader.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fetch messages and add them to the page.
+function fetchMessages(){
+  const url = '/feed';
+  fetch(url).then((response) => {
+    return response.json();
+  }).then((messages) => {
+    const messageContainer = document.getElementById('message-container');
+    if(messages.length == 0){
+     messageContainer.innerHTML = '<p>There are no posts yet.</p>';
+    }
+    else{
+     messageContainer.innerHTML = '';
+    }
+    messages.forEach((message) => {
+     const messageDiv = buildMessageDiv(message);
+     messageContainer.appendChild(messageDiv);
+    });
+  });
+}
+
+function buildMessageDiv(message){
+ const usernameDiv = document.createElement('div');
+ usernameDiv.classList.add("left-align");
+ usernameDiv.appendChild(document.createTextNode(message.user));
+
+ const timeDiv = document.createElement('div');
+ timeDiv.classList.add('right-align');
+ timeDiv.appendChild(document.createTextNode(new Date(message.timestamp)));
+
+ const headerDiv = document.createElement('div');
+ headerDiv.classList.add('message-header');
+ headerDiv.appendChild(usernameDiv);
+ headerDiv.appendChild(timeDiv);
+
+ const bodyDiv = document.createElement('div');
+ bodyDiv.classList.add('message-body');
+ bodyDiv.appendChild(document.createTextNode(message.text));
+
+ const messageDiv = document.createElement('div');
+ messageDiv.classList.add("message-div");
+ messageDiv.appendChild(headerDiv);
+ messageDiv.appendChild(bodyDiv);
+
+ return messageDiv;
+}
+
+// Fetch data and populate the UI of the page.
+function buildUI(){
+ fetchMessages();
+}


### PR DESCRIPTION
This PR creates a new html page: /feed which shows the messages from all users. This data is retrieved from the datastore.