### PR TITLE
Highlight any message prefixed with @

### DIFF
--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -100,8 +100,14 @@ function buildMessageDiv(message) {
   headerDiv.appendChild(document.createTextNode(my_message));
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('message-body');
-  bodyDiv.innerHTML = message.text;
-
+  var out_text = message.text.split(" ");
+  for (var i = 0; i < out_text.length; i++) {
+    if (out_text[i].substring(0,1) === "@")
+    {
+      out_text[i] = out_text[i].fontcolor("red");
+    }
+  }
+  bodyDiv.innerHTML = out_text.join(' ');
   const messageDiv = document.createElement('div');
   messageDiv.classList.add('message-div');
   messageDiv.appendChild(headerDiv);


### PR DESCRIPTION
Working on @mentions and #tags. This allows for simple recoloring of text by recognizing @ (easily changed to include #) in a word. Simple change with no functionality (for visual/logic purposes).

To be added: 
- @[user] only works with users, not any text
- Datastore/User change to make a username field (so @mentions won't have spaces in them)
- @[user] should link to a user's page
- #[tag] should link to a feed with that tag (to be implemented outside of mentions but should be easily added once a tag and its feed is easily accessible by URL)