### PR TITLE
Files for new check in feature map

### DIFF
--- a/src/main/java/com/google/codeu/servlets/SFServlet.java
+++ b/src/main/java/com/google/codeu/servlets/SFServlet.java
@@ -1,0 +1,63 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+import java.util.Scanner;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+
+@WebServlet("/sf-locations")
+public class SFServlet extends HttpServlet {
+
+    JsonArray sfLocationsArray;
+
+    @Override
+    public void init() {
+        sfLocationsArray = new JsonArray();
+        Gson gson = new Gson();
+        Scanner scanner = new Scanner(getServletContext().getResourceAsStream("/WEB-INF/sf-locations.csv"));
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            String[] cells = line.split(",");
+            String facilName = cells[0];
+            String facilType = cells[1].replaceAll("\\s+","");
+            String facilNickName = cells[2];
+            double lat = Double.parseDouble(cells[3]);
+            double lng = Double.parseDouble(cells[4]);
+
+            sfLocationsArray.add(gson.toJsonTree(new sfLocations(facilType, facilName, facilNickName, lat, lng)));
+        }
+        scanner.close();
+    }
+
+    
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+        response.setContentType("application/json");
+        response.getOutputStream().println(sfLocationsArray.toString());
+    }
+
+    private static class sfLocations {
+        String facilType;
+        String facilName;
+        String facilNickName;
+        String websiteLink;
+        double lat;
+        double lng;
+    
+
+        private sfLocations(String facilType, String facilName, String facilNickName, double lat, double lng) {
+        this.facilType = facilType;
+        this.facilName = facilName;
+        this.facilNickName = facilNickName;
+        this.lat = lat;
+        this.lng = lng;
+        }
+    }   
+}
+
+    

--- a/src/main/webapp/WEB-INF/sf-locations.csv
+++ b/src/main/webapp/WEB-INF/sf-locations.csv
@@ -1,0 +1,12 @@
+Fort Funston Doggie Beach,beach,Best Beach in Town,37.718806,-122.504370
+Pacifica State Beach,beach,Hawtest Beach for Paws,37.599196,-122.502011
+Baker Beach,beach,Insert Name,37.791781,-122.485199
+Golden Gate Park,park,The Funnest Park,37.769446,-122.486296
+Mclaren Park,park,Park for Cool Dogs Only,37.719771,-122.419045
+Alta Plaza Off Leash Dog Park,park,Park for Unleashed Doggies,37.791285,-122.438082
+Corona Heights Park,park,Insert Name,37.765481,-122.43169
+Dolores Park,park,Insert Name,37.75917,-122.426903
+Glen Canyon Park,trail,Beautifulest Trail,37.749682,-122.444865
+Leona Canyon Trail,trail,Most Exciting Trail for Dogs,37.786943,-122.151760
+Barbary Coast Trail,trail,The Prettiest Trail of All,37.784590,-122.408615
+Lands End Lookout,trail,Insert Name,37.785328,-122.507618

--- a/src/main/webapp/js/sfmap.js
+++ b/src/main/webapp/js/sfmap.js
@@ -1,0 +1,45 @@
+/*
+Description: javascript file corresponding to sf-map.html
+Author: Anna Kawakami 
+Created: 04/07/19
+Last Updated: 04/0/19
+File uses specific markers on map based on facility type.
+*/
+
+let map;
+    function sfMap() {
+        fetch('/sf-locations').then(function(response) {
+            return response.json();
+        }).then((sfLocations) => {
+
+            const map = new google.maps.Map(document.getElementById('map'), {
+                center: {lat: 35.78613674, lng: -119.4491591},
+                zoom:7
+            });
+
+          
+            const icons = {
+                park: {
+                    icon: 'markerimages/parks.png'
+                }, 
+                beach: {
+                    icon:'markerimages/water.png'          
+                }, 
+                trail: {
+                    icon: 'markerimages/play.png'
+                }
+            };
+
+            const markers = sfLocations.map(function(sfLocation, i) {
+                    return new google.maps.Marker({
+                        position: {lat: sfLocation.lat, lng: sfLocation.lng},
+                        icon: icons[sfLocation.facilType][icon],
+                        map: map
+                    });
+            });
+
+        });
+
+    } 
+
+    

--- a/src/main/webapp/sfmap.html
+++ b/src/main/webapp/sfmap.html
@@ -1,0 +1,18 @@
+<!-- 
+Description: Map showing locations public facilities in the LA, California area
+Author: Anna Kawakami 
+Created: 04/07/19
+Last Edited: 04/09/19-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title> San Francisco Dog Map </title>
+        <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDfEwbIKOYAeqpy7rd0w4DKrz0sNmSbeDg"></script>
+        <script src="/js/sf-map.js"></script>
+        <link rel="stylesheet" href="/css/facilitiesmap.css">
+    </head>
+    <body onload="sfMap();">
+        <h1>San Francisco Dog Map</h1>
+        <div id="map"></div>
+    </body>
+</html>


### PR DESCRIPTION
New files corresponding to map with check-in features. 
New map includes 12 dog-friendly locations in SF, corresponding markers depending on type of location, and nick names for the locations. 
Please note - Still fixing map bugs; does not load with devserver. 

Things to do - 
1. Connect check-ins initiated from feed (when feed code is created) with this map, e.g. show on map the number of check-ins per location. 
2. Change location marker to indicate which location user checked in with. 
3. (Stretch?) Create separate maps page with clickable check-in buttons on the map itself. 